### PR TITLE
Add instructions for deploying to the development server

### DIFF
--- a/deploy_development.sh
+++ b/deploy_development.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# path to development directory 
+dev_dir=/curc/admin/ood/development
+
+# path to ondemand-dev apps/sys directory 
+app_sys_dir=/var/www/ood/apps/sys
+
+# Confirm deployment
+read -p "Are you sure you want to deploy to the development server? (y/n): " confirm
+if [[ $confirm == [yY] ]]; then
+
+    # remove all current symlinks in /var/www/ood/apps/sys
+    $dev_dir/symlink_removal.sh  $app_sys_dir
+
+    # symlink all directories in $dev_dir/apps to /var/www/ood/apps/sys
+    $dev_dir/symlink_add.sh $dev_dir/apps $app_sys_dir
+
+else
+    echo "Operation cancelled."
+fi

--- a/deploy_readme.md
+++ b/deploy_readme.md
@@ -1,0 +1,49 @@
+# So you want to deploy, huh? 
+
+Alrighty. Let's do it! 
+
+First let's talk about the structure of our Open OnDemand servers. These servers have symlinks to items in either
+`/curc/admin/ood/development` or `/curc/admin/ood/production`. As you can tell by these folder 
+names, one is meant for the development environment while the other is meant for production. Both 
+of these directories are pointing to our [open_ondemand repo](https://github.com/ResearchComputing/open_ondemand) 
+on GitHub. However, the folder `development` points to the `dev` branch while the folder `production` 
+points to the `main` branch. This is the "best" solution I could think of, given we do not each have 
+access to our own `ondemand-dev` server. Additionally, each ondemand server will need to symlink to the 
+applications, thus, we need two different directories.
+
+## Making changes 
+
+To make changes on the production version of OOD, you should first create a branch of the `dev` branch 
+in `/curc/admin/ood/development` e.g. 
+```
+cd /curc/admin/ood/development
+git checkout -b add-deployment dev
+```
+
+You should then make your changes on this new branch (e.g. `add-deployment`). Once you are satisfied with the changes, 
+you can then create a PR to the `dev` branch. 
+
+Once we are ready to bring `dev` into `main`, we will then do a PR that merges the `dev` branch into `main`. We will then follow the steps in the section "Deploying to production server" below to deploy this new version of OOD on the production server. For steps on deploying to the development server, see the section "Deploying to development server" below.
+
+## Deploying to development server
+
+To make deploying the changes into development easy, I have created the script `deploy_development.sh`.
+This script automates the following steps (and has safety checks): 
+- Removes all symlinks in `/var/www/ood/apps/sys` 
+- Creates a new symlink in `/var/www/ood/apps/sys` for each application in `/curc/admin/ood/development/apps`
+
+The following steps should be performed: 
+1. Go to the directory `/curc/admin/ood/development` and switch to the branch you want to use.
+2. Make sure the branch you switched to is up-to-date e.g. do `git pull`, if 
+necessary. 
+3. Jump onto `ondemand-dev`
+4. Run the deploy script for the development server:
+```
+./deploy_development.sh 
+```
+
+## Deploying to production server
+
+Finally, we are here! 
+
+(In progress ...)

--- a/symlink_add.sh
+++ b/symlink_add.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+######################################################################################################
+# To symlink all sub directories in /path/to/dir to /path/to/gen/symlink, execute this script as 
+# follows:
+# 
+# ./symlink_add.sh /path/to/dir /path/to/gen/symlink
+######################################################################################################
+
+# define the source directory that contains the directories to symlink (e.g. /curc/admin/ood/development/apps)
+SOURCE_DIR=$1
+
+# define the target directory that will contain symlinks (e.g. /var/www/ood/apps/sys)
+TARGET_DIR=$2
+
+# find all subdirectories of the given path 
+app_dirs=$(find $SOURCE_DIR -mindepth 1 -maxdepth 1 -type d)
+
+# print the directories that will be symlinked to the target directory and symlink them 
+echo "The following symlinks will be created"
+for app in $app_dirs; do
+    echo "symlinking $app to $TARGET_DIR"
+done
+
+# Confirm removal
+read -p "Are you sure you want to add these symlinks? (y/n): " confirm
+if [[ $confirm == [yY] ]]; then
+    for app in $app_dirs; do
+        ln -s $app $TARGET_DIR
+    done 
+else
+    echo "Operation cancelled."
+fi

--- a/symlink_removal.sh
+++ b/symlink_removal.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+######################################################################################################
+# To remove all symlinks in the directory /path/to/dir, execute this script as follows:
+# 
+# ./symlink_removal.sh /path/to/dir
+######################################################################################################
+
+# Define the target directory to start searching from
+TARGET_DIR=$1
+
+# Find all directories containing at least one symlink
+dirs_w_symlink=$(find -L $TARGET_DIR -mindepth 1 -maxdepth 1 -xtype l)
+
+# List the symlinks to be removed
+echo "The following symlinks will be removed:"
+for dir in $dirs_w_symlink; do
+    echo "$dir"
+done
+
+# Confirm removal
+read -p "Are you sure you want to remove these symlinks? (y/n): " confirm
+if [[ $confirm == [yY] ]]; then
+    # Remove the symlinks
+    for dir in $dirs_w_symlink; do
+        unlink $dir
+        echo "unlinked $dir"
+    done
+else
+    echo "Operation cancelled."
+fi


### PR DESCRIPTION
In this PR I add `deploy_readme.md`, which provides details on deploying to the dev server and other useful information needed to understand the deployment process. Additionally, this PR contains scripts for automating deployment to the dev server. Essentially, these scripts remove all appropriate symlinks and then generate new symlinks to the development folder, with some safety checks along the way. 