### PR TITLE
Extend RStudio functionality for Alpine and Blanca

### DIFF
--- a/apps/rstudio_server/template/before.sh.erb
+++ b/apps/rstudio_server/template/before.sh.erb
@@ -1,50 +1,33 @@
 set -x
 
-export CLUSTER_NAME=<%= context.cluster %>
-
 # Find available port to run server on
 port=$(find_port ${host})
 
+# make directory that will hold all RStudio content
 mkdir /projects/$USER/.rstudioserver
 
-# Create singularity or apptainer as symlink so we can use them
-if [[ $CLUSTER_NAME == "blanca" ]]; then
-	if [[ ! -e ~/.singularity ]]; then
-    		mkdir -p ~/work/.singularity
-    		ln -sr ~/work/.singularity ~/.singularity
-	fi
-	export SINGULARITY_TMPDIR=/projects/$USER/.rstudioserver
-        export SINGULARITY_CACHEDIR=/projects/$USER/.rstudioserver
-	module load singularity
+# create Apptainer as symlink so we can use them
+if [[ ! -e ~/.apptainer ]]; then
+	mkdir -p ~/work/..apptainer
+	ln -sr ~/work/.apptainer ~/.apptainer
+fi
 
-else 
-	if [[ ! -e ~/.apptainer ]]; then
-    		mkdir -p ~/work/..apptainer
-    		ln -sr ~/work/.apptainer ~/.apptainer
-	fi
+# export environment variables for Apptainer items 
+export APPTAINER_TMPDIR=/projects/$USER/.rstudioserver
+export APPTAINER_CACHEDIR=/projects/$USER/.rstudioserver
+export RSTUDIO_SERVER_IMAGE=/curc/sw/containers/open_ondemand/<%= context.apptainer_image %>
 
-	export APPTAINER_TMPDIR=/projects/$USER/.rstudioserver
-	export APPTAINER_CACHEDIR=/projects/$USER/.rstudioserver
+# create overlay if it doesn't exist and add it to the user's projects directory
+if ! test -f "/projects/$USER/.rstudioserver/rstudio-server-4.2.2_overlay.img"; then
 
-	export RSTUDIO_SERVER_IMAGE=/curc/sw/containers/open_ondemand/<%= context.apptainer_image %>
-
-	# create overlay if it doesn't exist and add it to the user's projects directory
-	if ! test -f "/projects/$USER/.rstudioserver/rstudio-server-4.2.2_overlay.img"; then
-
-   		cd /projects/$USER/.rstudioserver
-   		apptainer overlay create --fakeroot --sparse --size 100000 rstudio-server-4.2.2_overlay.img
-
-	fi
-
-	export APPTAINER_OVERLAY=/projects/$USER/.rstudioserver/rstudio-server-4.2.2_overlay.img
+	cd /projects/$USER/.rstudioserver
+	apptainer overlay create --fakeroot --sparse --size 100000 rstudio-server-4.2.2_overlay.img
 
 fi
 
+# set environment variable for overlay and image so they can be used later
+export APPTAINER_OVERLAY=/projects/$USER/.rstudioserver/rstudio-server-4.2.2_overlay.img
 export RSTUDIO_SERVER_IMAGE=/curc/sw/containers/open_ondemand/<%= context.apptainer_image %>
-
-# Define a password and export it for RStudio authentication
-#password="$(create_passwd 16)"
-#export RSTUDIO_PASSWORD="${password}"
 
 <%-
   require 'securerandom'

--- a/apps/rstudio_server/template/script.sh.erb
+++ b/apps/rstudio_server/template/script.sh.erb
@@ -77,11 +77,7 @@ printf 'provider=sqlite\ndirectory=/var/lib/rstudio-server\n' > /projects/$USER/
 
 echo $CLUSTER_NAME
 
-# all singularity binds for the container 
-if [[ "${CLUSTER_NAME}" == "blanca" ]]; then
-	BINDS=/pl/active,/projects/$USER,/rc_scratch/$USER,/projects/$USER/.rstudioserver/run:/run,/projects/$USER/.rstudioserver/var-lib-rstudio-server:/var/lib/rstudio-server,/projects/$USER/.rstudioserver/database.conf:/etc/rstudio/database.conf,/curc/sw/containers/open_ondemand,/curc/sw/anaconda3,/curc/sw/anaconda,/curc/sw/anaconda2,/curc/sw/mambaforge-pypy3
-	singularity exec --bind $BINDS $RSTUDIO_SERVER_IMAGE $RSERVER --www-port="${port}" --auth-none=1 --server-user=$USER
-else
-	BINDS=/projects/$USER,/pl/active,/scratch/alpine/$USER,/projects/$USER/.rstudioserver/run:/run,/projects/$USER/.rstudioserver/var-lib-rstudio-server:/var/lib/rstudio-server,/projects/$USER/.rstudioserver/database.conf:/etc/rstudio/database.conf,/curc/sw/containers/open_ondemand,/curc/sw/anaconda3,/curc/sw/anaconda,/curc/sw/anaconda2,/curc/sw/mambaforge-pypy3
-	apptainer exec --bind $BINDS --userns --overlay $APPTAINER_OVERLAY:ro $RSTUDIO_SERVER_IMAGE $RSERVER --www-port="${port}" --auth-none=1 --server-user=$USER
-fi
+# all Apptainer binds for the container 
+BINDS=/projects/$USER,/pl/active,$SCRATCHDIR/$USER,/projects/$USER/.rstudioserver/run:/run,/projects/$USER/.rstudioserver/var-lib-rstudio-server:/var/lib/rstudio-server,/projects/$USER/.rstudioserver/database.conf:/etc/rstudio/database.conf,/curc/sw/containers/open_ondemand,/curc/sw/anaconda3,/curc/sw/anaconda,/curc/sw/anaconda2,/curc/sw/mambaforge-pypy3
+apptainer exec --bind $BINDS --userns --overlay $APPTAINER_OVERLAY:ro $RSTUDIO_SERVER_IMAGE $RSERVER --www-port="${port}" --auth-none=1 --server-user=$USER
+


### PR DESCRIPTION
In this PR I modify `before.sh.erb` and `script.sh.erb` so that RStudio overlays can be created on both Alpine and Blanca using Apptainer. Additionally, I remove if statements created for the different clusters by using the environment variable `$SCRATCHDIR`. Lastly, I do a modest amount of clean-up in the files I touched. 