### PR TITLE
Add ICS Desktop application 

### DIFF
--- a/apps/ics_desktop/LICENSE.txt
+++ b/apps/ics_desktop/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2016-2018 Ohio Supercomputer Center
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/ics_desktop/README.md
+++ b/apps/ics_desktop/README.md
@@ -1,0 +1,16 @@
+# ICS Desktop Application 
+
+The provided Core Desktop elements were modified and initially inspired by 
+[OSC's Desktop setup.](https://github.com/OSC/ondemand/tree/master/apps/bc_desktop). We appreciate 
+all of the hard work this team has done. Without them, creating apps such as this 
+would not be possible! This particular application was created specifically for the 
+ICS group it opens a core desktop on the groups blogin-ics2 node. Only individuals who 
+are part of the icsgrp can access this application. 
+
+## How does it work?
+
+This app launches a remote desktop session.
+
+## License
+
+- MIT, see `LICENSE` file.

--- a/apps/ics_desktop/form.yml
+++ b/apps/ics_desktop/form.yml
@@ -1,0 +1,38 @@
+---
+attributes:
+  desktop: "mate"
+  bc_vnc_idle: 0
+  bc_vnc_resolution:
+    required: true
+  node_type: null
+  bc_queue: blanca-ics-interactive
+  bc_account:
+    widget: text_field
+    label: "Account"
+    value: "blanca-ics"
+  bc_num_hours:
+    widget: "number_field"
+    label: "Time in hours"
+    value: 4
+    min: 1
+    max: 168
+    help: "Maximum number of hours is 168."
+  num_cores:
+    widget: "number_field"
+    label: "Number of cores"
+    value: 4
+    help: |
+        Maximum number of cores is 6.
+    min: 1
+    max: 6
+    step: 1
+    id: 'num_cores'
+form:
+  - bc_vnc_idle
+  - desktop
+  - bc_account
+  - bc_num_hours
+  - num_cores
+  - node_type
+  - bc_queue
+  - bc_vnc_resolution

--- a/apps/ics_desktop/manifest.yml
+++ b/apps/ics_desktop/manifest.yml
@@ -1,0 +1,8 @@
+---
+name: ICS Desktop
+icon: fa://desktop
+category: Interactive Apps
+subcategory: Desktops
+role: batch_connect
+description: |
+      This is a custom application to launch an interactive desktop on blogin-ics2.

--- a/apps/ics_desktop/submit.yml.erb
+++ b/apps/ics_desktop/submit.yml.erb
@@ -1,0 +1,13 @@
+---
+cluster: blanca
+script:
+  native:
+    - "-n"
+    - "<%= num_cores.blank? ? 1 : num_cores.to_i %>"
+    - "-N 1"
+    - "--qos=blanca-ics"
+    - "--mem-per-cpu=4G"
+batch_connect:
+  template: vnc
+  set_host: "host=$(hostname)"
+

--- a/apps/ics_desktop/template/before.sh.erb
+++ b/apps/ics_desktop/template/before.sh.erb
@@ -1,0 +1,2 @@
+# Export the module function if it exists
+[[ $(type -t module) == "function" ]] && export -f module

--- a/apps/ics_desktop/template/desktops/gnome.sh
+++ b/apps/ics_desktop/template/desktops/gnome.sh
@@ -1,0 +1,17 @@
+# Turn off screensaver
+gconftool-2 --set -t boolean /apps/gnome-screensaver/idle_activation_enabled false
+
+# Use browser window instead in nautilus
+gconftool-2 --set -t boolean /apps/nautilus/preferences/always_use_browser true
+
+# Disable the disk check utility on autostart
+mkdir -p "${HOME}/.config/autostart"
+cat "/etc/xdg/autostart/gdu-notification-daemon.desktop" <(echo "X-GNOME-Autostart-enabled=false") > "${HOME}/.config/autostart/gdu-notification-daemon.desktop"
+
+# Remove any preconfigured monitors
+if [[ -f "${HOME}/.config/monitors.xml" ]]; then
+  mv "${HOME}/.config/monitors.xml" "${HOME}/.config/monitors.xml.bak"
+fi
+
+# Start up Gnome desktop (block until user logs out of desktop)
+/etc/X11/xinit/Xsession gnome-session

--- a/apps/ics_desktop/template/desktops/kde.sh
+++ b/apps/ics_desktop/template/desktops/kde.sh
@@ -1,0 +1,1 @@
+startkde

--- a/apps/ics_desktop/template/desktops/mate.sh
+++ b/apps/ics_desktop/template/desktops/mate.sh
@@ -1,0 +1,30 @@
+# Turn off screensaver (this may not exist at all)
+gsettings set org.mate.screensaver idle-activation-enabled false
+
+# Disable gnome-keyring-daemon
+gsettings set org.mate.session gnome-compat-startup "['smproxy']"
+
+# Remove any preconfigured monitors
+if [[ -f "${HOME}/.config/monitors.xml" ]]; then
+  mv "${HOME}/.config/monitors.xml" "${HOME}/.config/monitors.xml.bak"
+fi
+
+# Disable useless services on autostart
+AUTOSTART="${HOME}/.config/autostart"
+rm -fr "${AUTOSTART}"    # clean up previous autostarts
+mkdir -p "${AUTOSTART}"
+for service in "gnome-keyring-gpg" "gnome-keyring-pkcs11" "gnome-keyring-secrets" "gnome-keyring-ssh" "mate-volume-control-applet" "polkit-mate-authentication-agent-1" "pulseaudio" "rhsm-icon" "spice-vdagent" "xfce4-power-manager"; do
+  cat "/etc/xdg/autostart/${service}.desktop" <(echo "X-MATE-Autostart-enabled=false") > "${AUTOSTART}/${service}.desktop"
+done
+
+# Disable pulseaudio
+# Warning: If you disable pulseaudio you get flooded with warning messages
+#PULSE_CONFIG="${HOME}/.config/pulse/client.conf"
+#mkdir -p "$(dirname "${PULSE_CONFIG}")"
+#echo "autospawn = no" > "${PULSE_CONFIG}"
+
+# Run Mate Terminal as login shell (sets proper TERM)
+dconf write /org/mate/terminal/profiles/default/login-shell true
+
+# Start up mate desktop (block until user logs out of desktop)
+mate-session

--- a/apps/ics_desktop/template/desktops/xfce.sh
+++ b/apps/ics_desktop/template/desktops/xfce.sh
@@ -1,0 +1,44 @@
+# Remove any preconfigured monitors
+if [[ -f "${HOME}/.config/monitors.xml" ]]; then
+  mv "${HOME}/.config/monitors.xml" "${HOME}/.config/monitors.xml.bak"
+fi
+
+# Copy over default panel if doesn't exist, otherwise it will prompt the user
+PANEL_CONFIG="${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml"
+if [[ ! -e "${PANEL_CONFIG}" ]]; then
+  mkdir -p "$(dirname "${PANEL_CONFIG}")"
+  cp "/etc/xdg/xfce4/panel/default.xml" "${PANEL_CONFIG}"
+fi
+
+# Disable startup services
+xfconf-query -c xfce4-session -p /startup/ssh-agent/enabled -n -t bool -s false
+xfconf-query -c xfce4-session -p /startup/gpg-agent/enabled -n -t bool -s false
+
+# Disable useless services on autostart
+AUTOSTART="${HOME}/.config/autostart"
+rm -fr "${AUTOSTART}"    # clean up previous autostarts
+mkdir -p "${AUTOSTART}"
+for service in "pulseaudio" "rhsm-icon" "spice-vdagent" "tracker-extract" "tracker-miner-apps" "tracker-miner-user-guides" "xfce4-power-manager" "xfce-polkit"; do
+  echo -e "[Desktop Entry]\nHidden=true" > "${AUTOSTART}/${service}.desktop"
+done
+
+# Run Xfce4 Terminal as login shell (sets proper TERM)
+TERM_CONFIG="${HOME}/.config/xfce4/terminal/terminalrc"
+if [[ ! -e "${TERM_CONFIG}" ]]; then
+  mkdir -p "$(dirname "${TERM_CONFIG}")"
+  sed 's/^ \{4\}//' > "${TERM_CONFIG}" << EOL
+    [Configuration]
+    CommandLoginShell=TRUE
+EOL
+else
+  sed -i \
+    '/^CommandLoginShell=/{h;s/=.*/=TRUE/};${x;/^$/{s//CommandLoginShell=TRUE/;H};x}' \
+    "${TERM_CONFIG}"
+fi
+
+# launch dbus first through eval becuase it can conflict with a conda environment
+# see https://github.com/OSC/ondemand/issues/700
+eval $(dbus-launch --sh-syntax)
+
+# Start up xfce desktop (block until user logs out of desktop)
+xfce4-session

--- a/apps/ics_desktop/template/script.sh.erb
+++ b/apps/ics_desktop/template/script.sh.erb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Change working directory to user's home directory
+cd "${HOME}"
+
+# Reset module environment (may require login shell for some HPC clusters)
+module purge && module restore
+
+# Ensure that the user's configured login shell is used
+export SHELL="$(getent passwd $USER | cut -d: -f7)"
+
+# Start up desktop
+echo "Launching desktop '<%= context.desktop %>'..."
+source "<%= session.staged_root.join("desktops", "#{context.desktop}.sh") %>"
+echo "Desktop '<%= context.desktop %>' ended..."


### PR DESCRIPTION
In this PR I add the ICS desktop application. This is a custom application specifically for the 
ICS group. It opens a core desktop on the groups `blogin-ics2` node.