### PR TITLE
Add newer version of VS-Code Server to the available options 

### DIFF
--- a/apps/vs_code_server/form.yml.erb
+++ b/apps/vs_code_server/form.yml.erb
@@ -22,6 +22,7 @@ attributes:
      widget: "select"
      label: "Code-Server version"
      options:
+       - ["4.105.1", "4.105.1"]
        - ["4.16.1", "4.16.1"]
        - ["4.14.1", "4.14.1"]
   cluster:


### PR DESCRIPTION
In this PR I add version `4.105.1` of VS-Code Server to the available `version` options in `form.yml.erb`. This version has been installed under our software stack and is accessible. 